### PR TITLE
Add YAML-based model parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,16 @@ RUN apt-get update && apt-get install -y \
     python3-pip git && \
     rm -rf /var/lib/apt/lists/*
 
-# Install vllm
+# Install dependencies
 RUN pip install --upgrade pip && \
-    pip install vllm[audio] transformers==4.52.4 
+    pip install \
+        vllm[audio] \
+        transformers==4.52.4 \
+        fastapi \
+        uvicorn[standard] \
+        pyyaml
 
 # Default command
-CMD ["vllm", "serve", "openai/whisper-large-v3", "--host", "0.0.0.0", "--port", "8917", "--trust-remote-code", "--gpu-memory-utilization", "0.5", "--enforce-eager"]
+CMD ["python", "app.py"]
 # docker build -t openai-whisper .
 # docker run --gpus 1 -p 8883:8917 --name openai-whisper whisper-openai

--- a/app.py
+++ b/app.py
@@ -2,31 +2,91 @@
 from fastapi import FastAPI
 from transformers import pipeline
 import torch
+from typing import Any, Dict, Optional
+from pydantic import BaseModel
+import yaml
+from pathlib import Path
 
 app = FastAPI()
 
 # Load the Whisper model
-# You might want to specify a device if you have a GPU, e.g., device=0 for GPU
 pipe = pipeline(
     "automatic-speech-recognition",
     model="openai/whisper-large-v3",
-    torch_dtype=torch.float16, # Use float16 for potentially faster inference on compatible hardware
-    device="cuda:0" if torch.cuda.is_available() else "cpu"
+    torch_dtype=torch.float16,  # Use float16 for potentially faster inference on compatible hardware
+    device="cuda:0" if torch.cuda.is_available() else "cpu",
 )
+
+PARAMS_FILE = Path("generation_params.yaml")
+
+
+class GenerationParameters(BaseModel):
+    """Configurable generation parameters for Whisper."""
+
+    max_new_tokens: Optional[int] = 448
+    num_beams: Optional[int] = 1
+    condition_on_prev_tokens: Optional[bool] = False
+    compression_ratio_threshold: Optional[float] = 1.35
+    temperature: Optional[tuple[float, ...]] = (
+        0.0,
+        0.2,
+        0.4,
+        0.6,
+        0.8,
+        1.0,
+    )
+    logprob_threshold: Optional[float] = -1.0
+    no_speech_threshold: Optional[float] = 0.6
+    return_timestamps: Optional[bool] = True
+    task: Optional[str] = "transcribe"
+
+
+def load_parameters() -> Dict[str, Any]:
+    """Load parameters from the YAML file, creating it if necessary."""
+    if PARAMS_FILE.exists():
+        with PARAMS_FILE.open("r") as f:
+            data = yaml.safe_load(f) or {}
+    else:
+        params = GenerationParameters().dict(exclude_none=True)
+        with PARAMS_FILE.open("w") as f:
+            yaml.safe_dump(params, f)
+        data = params
+    return data
+
+
+def save_parameters(params: Dict[str, Any]) -> None:
+    """Write parameters to the YAML file."""
+    with PARAMS_FILE.open("w") as f:
+        yaml.safe_dump(params, f)
+
+
+@app.get("/v1/model/parameters/")
+async def get_parameters() -> Dict[str, Any]:
+    """Return the current generation parameters."""
+    return load_parameters()
+
+
+@app.patch("/v1/model/parameters/")
+async def update_parameters(params: GenerationParameters):
+    """Update generation parameters for the Whisper model."""
+    stored = load_parameters()
+    stored.update(params.dict(exclude_unset=True))
+    save_parameters(stored)
+    return {"message": "Parameters updated", "parameters": stored}
+
 
 @app.post("/v1/audio/transcriptions/")
 async def transcribe_audio(audio_path: str):
-    """
-    Transcribes an audio file using the Whisper model.
-    """
-    # Replace with actual audio handling (e.g., receiving audio as bytes or file upload)
-    # For simplicity, this example assumes a path to a local audio file within the container
+    """Transcribe an audio file using the Whisper model."""
     try:
-        result = pipe(audio_path, generate_kwargs={"task": "transcribe"})
+        generation_params = load_parameters()
+        result = pipe(audio_path, generate_kwargs=generation_params)
         return {"transcription": result["text"]}
     except Exception as e:
         return {"error": str(e)}
 
+
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8917)

--- a/generation_params.yaml
+++ b/generation_params.yaml
@@ -1,0 +1,15 @@
+max_new_tokens: 448
+num_beams: 1
+condition_on_prev_tokens: false
+compression_ratio_threshold: 1.35
+temperature:
+- 0.0
+- 0.2
+- 0.4
+- 0.6
+- 0.8
+- 1.0
+logprob_threshold: -1.0
+no_speech_threshold: 0.6
+return_timestamps: true
+task: transcribe


### PR DESCRIPTION
## Summary
- store Whisper generation parameters in `generation_params.yaml`
- load parameters from YAML when transcribing
- allow parameter endpoint to update the YAML file
- run FastAPI service in Docker instead of `vllm serve`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_6865212b68f48322bb1e060f1e5a41ae